### PR TITLE
Make UTF-8-BOM .eslintrc files (that contain JSON-style YAML) work

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -53,7 +53,10 @@ function loadConfig(filePath) {
 
     if (filePath) {
         try {
-            config = yaml.safeLoad(stripComments(fs.readFileSync(filePath, "utf8"))) || {};
+            var configFile = fs.readFileSync(filePath, "utf8")
+            // remove potential bom
+            configFile = configFile.replace(/^\uFEFF/, '');
+            config = yaml.safeLoad(stripComments(configFile)) || {};
         } catch (e) {
             debug("Error reading YAML file: " + filePath);
             e.message = "Cannot read config file: " + filePath + "\nError: " + e.message;


### PR DESCRIPTION
UTF-8 with BOM is still UTF-8.  Fix loading of .eslintrc files and fix https://github.com/eslint/eslint/issues/1443
